### PR TITLE
Update access level from open to public for funcs that are not @objc

### DIFF
--- a/Sources/SwiftyNats/NatsClient/NatsClient+Connection.swift
+++ b/Sources/SwiftyNats/NatsClient/NatsClient+Connection.swift
@@ -12,7 +12,7 @@ extension NatsClient: NatsConnection {
     // MARK: - Implement NatsConnection Protocol
     
     /// Connect to the NATS server
-    open func connect() throws {
+    public func connect() throws {
         logger.debug("Try to connect.")
         guard self.state != .connected else {
             logger.info("Already connected, skip connection.")
@@ -41,7 +41,7 @@ extension NatsClient: NatsConnection {
     }
 
     /// Disconnect from the NATS server
-    open func disconnect() {
+    public func disconnect() {
         logger.debug("Try to disconnect.")
         do {
             try self.channel?.close().wait()
@@ -58,7 +58,7 @@ extension NatsClient: NatsConnection {
 
     // MARK: - Internal Methods
 
-    open func reconnect() throws {
+    public func reconnect() throws {
         self.fire(.reconnecting)
         
         // disconnect - if not already

--- a/Sources/SwiftyNats/NatsClient/NatsClient+EventBus.swift
+++ b/Sources/SwiftyNats/NatsClient/NatsClient+EventBus.swift
@@ -8,34 +8,34 @@ extension NatsClient: NatsEventBus {
     // MARK: - Implement NatsEvents Protocol
     
     @discardableResult
-    open func on(_ events: [NatsEvent], _ handler: @escaping (NatsEvent) -> Void) -> String {
+    public func on(_ events: [NatsEvent], _ handler: @escaping (NatsEvent) -> Void) -> String {
         
         return self.addListeners(for: events, using: handler)
 
     }
     
     @discardableResult
-    open func on(_ event: NatsEvent, _ handler: @escaping (NatsEvent) -> Void) -> String {
+    public func on(_ event: NatsEvent, _ handler: @escaping (NatsEvent) -> Void) -> String {
         
         return self.addListeners(for: [event], using: handler)
         
     }
     
     @discardableResult
-    open func on(_ event: NatsEvent, autoOff: Bool, _ handler: @escaping (NatsEvent) -> Void) -> String {
+    public func on(_ event: NatsEvent, autoOff: Bool, _ handler: @escaping (NatsEvent) -> Void) -> String {
         
         return self.addListeners(for: [event], using: handler, autoOff)
         
     }
     
     @discardableResult
-    open func on(_ events: [NatsEvent], autoOff: Bool, _ handler: @escaping (NatsEvent) -> Void) -> String {
+    public func on(_ events: [NatsEvent], autoOff: Bool, _ handler: @escaping (NatsEvent) -> Void) -> String {
         
         return self.addListeners(for: events, using: handler, autoOff)
         
     }
     
-    open func off(_ id: String) {
+    public func off(_ id: String) {
         
         self.removeListener(id)
         

--- a/Sources/SwiftyNats/NatsClient/NatsClient+Publish.swift
+++ b/Sources/SwiftyNats/NatsClient/NatsClient+Publish.swift
@@ -10,22 +10,22 @@ extension NatsClient: NatsPublish {
 
     // MARK: - Implement NatsPublish Protocol
 
-    open func publish(_ payload: String, to subject: String) {
+    public func publish(_ payload: String, to subject: String) {
         logger.info("publish \(payload.count) characters to subject \(subject)")
         sendMessage(NatsMessage.publish(payload: payload, subject: subject))
     }
 
-    open func publish(_ payload: String, to subject: NatsSubject) {
+    public func publish(_ payload: String, to subject: NatsSubject) {
         publish(payload, to: subject.subject)
     }
 
-    open func reply(to message: NatsMessage, withPayload payload: String) {
+    public func reply(to message: NatsMessage, withPayload payload: String) {
         guard let replySubject = message.replySubject else { return }
         logger.info("reply \(payload.count) characters to subject \(replySubject.subject)")
         publish(payload, to: replySubject.subject)
     }
 
-    open func publishSync(_ payload: String, to subject: String) throws {
+    public func publishSync(_ payload: String, to subject: String) throws {
 
         let group = DispatchGroup()
         group.enter()
@@ -47,11 +47,11 @@ extension NatsClient: NatsPublish {
 
     }
 
-    open func publishSync(_ payload: String, to subject: NatsSubject) throws {
+    public func publishSync(_ payload: String, to subject: NatsSubject) throws {
         try publishSync(payload, to: subject.subject)
     }
 
-    open func replySync(to message: NatsMessage, withPayload payload: String) throws {
+    public func replySync(to message: NatsMessage, withPayload payload: String) throws {
         guard let replySubject = message.replySubject else { return }
         try publishSync(payload, to: replySubject.subject)
     }

--- a/Sources/SwiftyNats/NatsClient/NatsClient+Queue.swift
+++ b/Sources/SwiftyNats/NatsClient/NatsClient+Queue.swift
@@ -16,7 +16,7 @@ extension NatsClient: NatsQueue {
         return 500 // milliseconds
     }
 
-    open func flushQueue(maxWait: TimeInterval? = nil) throws {
+    public func flushQueue(maxWait: TimeInterval? = nil) throws {
         
         let startTimestamp = Date().timeIntervalSinceReferenceDate
 

--- a/Sources/SwiftyNats/NatsClient/NatsClient+Subscribe.swift
+++ b/Sources/SwiftyNats/NatsClient/NatsClient+Subscribe.swift
@@ -11,7 +11,7 @@ extension NatsClient: NatsSubscribe {
     // MARK: - Implement NatsSubscribe Protocol
 
     @discardableResult
-    open func subscribe(to subject: String, _ handler: @escaping (NatsMessage) -> Void) -> NatsSubject {
+    public func subscribe(to subject: String, _ handler: @escaping (NatsMessage) -> Void) -> NatsSubject {
         logger.info("subscribe to subject \(subject)")
         let nsub = NatsSubject(subject: subject)
 
@@ -23,7 +23,7 @@ extension NatsClient: NatsSubscribe {
     }
 
     @discardableResult
-    open func subscribe(to subject: String, asPartOf queue: String, _ handler: @escaping (NatsMessage) -> Void) -> NatsSubject {
+    public func subscribe(to subject: String, asPartOf queue: String, _ handler: @escaping (NatsMessage) -> Void) -> NatsSubject {
         logger.info("subscribe to subject \(subject)")
         let nsub = NatsSubject(subject: subject)
 
@@ -35,14 +35,14 @@ extension NatsClient: NatsSubscribe {
 
     }
 
-    open func unsubscribe(from subject: NatsSubject) {
+    public func unsubscribe(from subject: NatsSubject) {
         logger.info("unsubscribe from subject \(subject)")
         self.sendMessage(NatsMessage.unsubscribe(sid: subject.id))
         self.subjectHandlerStore[subject] = nil
 
     }
 
-    open func unsubscribeSync(from subject: NatsSubject) throws {
+    public func unsubscribeSync(from subject: NatsSubject) throws {
         logger.info("unsubscribe syncrnon from subject \(subject)")
         let group = DispatchGroup()
         group.enter()
@@ -67,12 +67,12 @@ extension NatsClient: NatsSubscribe {
     }
 
     @discardableResult
-    open func subscribeSync(to subject: String, _ handler: @escaping (NatsMessage) -> Void) throws -> NatsSubject {
+    public func subscribeSync(to subject: String, _ handler: @escaping (NatsMessage) -> Void) throws -> NatsSubject {
         return try subSync(to: subject, asPartOf: "", handler)
     }
 
     @discardableResult
-    open func subscribeSync(to subject: String, asPartOf queue: String, _ handler: @escaping (NatsMessage) -> Void) throws -> NatsSubject {
+    public func subscribeSync(to subject: String, asPartOf queue: String, _ handler: @escaping (NatsMessage) -> Void) throws -> NatsSubject {
         return try subSync(to: subject, asPartOf: queue, handler)
     }
 


### PR DESCRIPTION
Replace **`open func`** by **`public func`** to silence Xcode warnings as functions does not use **`@objc`** keyword so `Non-'@objc' instance method in extensions cannot be overridden`