### PR TITLE
Fix/thread warning

### DIFF
--- a/Sources/SwiftyNats/NatsClient/NatsClient+Connection.swift
+++ b/Sources/SwiftyNats/NatsClient/NatsClient+Connection.swift
@@ -34,6 +34,11 @@ extension NatsClient: NatsConnection {
             RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.1))
         } while self.connectionError == nil && self.state != .connected && Date().timeIntervalSince(startDate) < timeout
 
+        if Date().timeIntervalSince(startDate) >= timeout {
+            logger.error("Timeout while connecting.")
+            throw NatsConnectionError("Timeout while connecting.")
+        }
+        
         if let error = self.connectionError {
             logger.error("Error while connectig.")
             throw error

--- a/Sources/SwiftyNats/NatsClient/NatsClient.swift
+++ b/Sources/SwiftyNats/NatsClient/NatsClient.swift
@@ -91,7 +91,7 @@ open class NatsClient: NSObject {
 // MARK: - Protocols
 
 protocol NatsConnection {
-    func connect() throws
+    func connect(_ timeout: CGFloat) throws
     func disconnect()
 }
 


### PR DESCRIPTION
Wait for the connection to established without using `self.dispatchGroup.wait()` to silence Xcode warning about threads priority inversion.
```
Thread running at QOS_CLASS_USER_INTERACTIVE waiting on a lower QoS thread running at QOS_CLASS_DEFAULT. Investigate ways to avoid priority inversions
```